### PR TITLE
Make sure section belongs to survey

### DIFF
--- a/app/models/survey/section.rb
+++ b/app/models/survey/section.rb
@@ -4,6 +4,7 @@ class Survey::Section < ActiveRecord::Base
   
   # relations
   has_many :questions
+  belongs_to :survey
   
   #rails 3 attr_accessible support
   if Rails::VERSION::MAJOR < 4


### PR DESCRIPTION
There are fast queries I can't run because this association doesn't exist. 